### PR TITLE
ERROR: "There is no route for the path..." #47

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -75,4 +75,3 @@ jabbslad:basic-auth
 react-template-helper
 izzilab:material-ui
 deanius:promise
-kadira:flow-router

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -93,7 +93,6 @@ jquery@1.11.4
 jsx@0.2.3
 juliancwirko:s-alert@2.4.2
 juliancwirko:s-alert-stackslide@1.1.4
-kadira:flow-router@2.10.1
 less@2.5.1
 livedata@1.0.15
 localstorage@1.0.5


### PR DESCRIPTION
This was caused by flow-router package which conflicts with iron-router package already in use.
Hence, I've removed the flow-router package.
Signed-off-by: Suhaib Khan suheb.work@gmail.com
