### PR TITLE
Fixing invalid propType warning in ReadingProse.

### DIFF
--- a/client/views/reading/ReadingProse.jsx
+++ b/client/views/reading/ReadingProse.jsx
@@ -30,7 +30,7 @@ ReadingProse = React.createClass({
             showNumber = this.props.text[i-1].n_1 != text.n_1;
           }
           if(showNumber) {
-            numbering = text.n_1;
+            numbering = (text.n_1).toString();
           }
         }
 


### PR DESCRIPTION
Fixes the following warning:
`Warning: Failed propType: Invalid prop 'numbering' of type 'number' supplied to 'ReadingText', expected 'string'. Check the render method of 'ReadingProse'.`
Signed-off-by: Suhaib Khan suheb.work@gmail.com
