### PR TITLE
Fix sorting and deduping of search keys

### DIFF
--- a/client/views/search/SearchTools.jsx
+++ b/client/views/search/SearchTools.jsx
@@ -39,19 +39,6 @@ SearchTools = React.createClass({
 			if (err) {
 				console.log(err);
 			} else {
-				res.authors.sort((a, b) => {
-					let sortVal = 1;
-					if (a.english_name > b.english_name) {
-						sortVal = 1;
-					} else if (b.english_name > a.english_name) {
-						sortVal = -1;
-					} else {
-						sortVal = 0;
-					}
-
-					return sortVal;
-				});
-
 				this.setState({
 					languages: res.languages,
 					corpora: res.corpora,

--- a/server/methods/searchTools.js
+++ b/server/methods/searchTools.js
@@ -5,6 +5,16 @@ import cache from '/server/cache';
 
 const CACHE_KEY = 'searchTools_cache_key'
 
+function getDistinctFieldInWorks(field) {
+	// NOTE: Works._collection.rawCollection() will only work on the server.
+	// This is fine for now, because this file only runs on the server, but
+	// there would need to be a workaround (or a `Meteor.isServer` check) if
+	// the browser wanted to run this file.
+	return Works._collection.rawCollection().distinct(field, {
+		[field]: { $exists: true, $nin: ['', null] }
+	});
+}
+
 Meteor.methods({
 	searchTools() {
 		const cachedResults = cache.get(CACHE_KEY);
@@ -12,42 +22,46 @@ Meteor.methods({
 		if (cachedResults) {
 			return {
 				...cachedResults,
-				authors: Authors.find({ _id: { $in: cachedResults.authors } }).fetch()
+				authors: Authors.find({
+					_id: { $in: cachedResults.authors.map(a => new Mongo.ObjectID(a)) },
+				 }, {
+					 sort: { english_name: 1 }
+				 }).fetch()
 			};
 		}
 
-		// NOTE: Works._collection.rawCollection() will only work on the server.
-		// This is fine for now, because this file only runs on the server, but
-		// there would need to be a workaround (or a `Meteor.isServer` check) if
-		// the browser wanted to run this file.
-		const languagesPromise = Works._collection.rawCollection().distinct('workLanguage', {
-			workLanguage: { $nin: ['', null] }
-		});
-		const corporaPromise = Works._collection.rawCollection().distinct('corpus', {
-			corpus: { $nin: ['', null] }
-		});
-		const worksAuthorsRaw = Works.find({ authors: { $exists: true } }, {
-			sort: { 'authors.english_name': 1 },
-			fields: { authors: true },
-		}).map(doc => doc.authors[0]);
+		const languagesPromise = getDistinctFieldInWorks('language');
+		const corporaPromise = getDistinctFieldInWorks('corpus');
+		const worksAuthorsPromise = getDistinctFieldInWorks('authors');
 
 		return Promise.all([
 			languagesPromise,
-			corporaPromise
-		]).then(([ languages, corpora ]) => {
+			corporaPromise,
+			worksAuthorsPromise
+		]).then(([ languages, corpora, authorsRaw ]) => {
+			languages = languages.sort();
+			corpora = corpora.sort();
+			authorsRaw = authorsRaw.map(a => a.toString());
+
 			cache.set(CACHE_KEY, {
-				...results,
+				languages,
+				corpora,
 				// `languages` and `corpora` are reasonably small, and
 				// unlikely to grow dramatically, so it seems okay to
 				// store them as is in the cache. Storing `authors`
 				// wholesale, on the other hand, would dramatically
 				// increase the size of the cached document, so just
 				// store the `_id`s.
-				authors: worksAuthorsRaw
+				authors: authorsRaw,
 			});
 
-			const authorsRaw = Authors.find({ _id: { $in: worksAuthorsRaw } }).fetch();
-			const authors = Array.from(new Set(authorsRaw));
+			const authors = Authors.find({
+				// NOTE: The values of `authorsRaw` need to be converted to Strings
+				// (above) and then converted back into ObjectIDs for this query to work.
+				_id: { $in: authorsRaw.map(a => new Mongo.ObjectID(a)) }
+			}, {
+				sort: { english_name: 1 }
+			}).fetch();
 
 			return {
 				languages,


### PR DESCRIPTION
With the fix in #101, a regression meant that results were no longer
sorted. This fix restores sorting and further optimizes `Authors` lookup. It also removes the redundant `sort()` in the client-side `SearchTools` view.

Hi @lukehollis, thanks for merging my previous PR in so quickly! Unfortunately, I found a regression in what I pushed up earlier -- sorry for not catching it sooner! This PR patches sorting back in, and it irons out some of the kinks that were still present in the `Authors` lookup. I ran into some strange behavior with ObjectIDs, and the only fix seemed to be explicitly converting them to Strings and then to (back?) to ObjectIDs. I'd be happy to dig into this further if it seems like it'll create a bottleneck. A shallow dig showed that the `distinct()` call is returning an array of `objects`, but they _aren't_ instances of `Mongo.ObjectID` -- that seems to be the heart of the problem, but I'm not sure if it's a Mongo problem or a Meteor-wrapping-Mongo problem. 

Separately, MongoDB doesn't allow sorting with `distinct` queries, unfortunately, but I think that `languages` and `corpora` should be small enough to sort in memory (and they'll only be sorted once every half-hour with the current cache TTL).